### PR TITLE
Add check to catch invalid domains

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -167,6 +167,7 @@ class Home extends React.Component {
       'sympatico.ca', 
       'rogers.com',
     ]
+    var isValid = false;
     if (email.includes('@')) {
       let domain = email.split('@');
       // compare email domain to our list object
@@ -193,6 +194,7 @@ class Home extends React.Component {
             })
           }
         }
+        
         this.state.domainList.map((domState) => {
             if (domState.dom === domain[1]) {
               if (mailType === 'email') {
@@ -201,7 +203,9 @@ class Home extends React.Component {
                 this.setState({
                   department: {key: domState.key},
                   isEmailDomainValid: true,
+                  isCanadaEmail: false,
                 })
+                isValid = true;
                 console.log("depat key" + domState.key)
               } else {
                 this.setState({
@@ -213,7 +217,7 @@ class Home extends React.Component {
         })
 
         // Add check for unrecognized domains that are not in invalid domain list
-        if(!this.state.isEmailDomainValid) {
+        if(!isValid && mailType === 'email') {
           this.setState({
             isCanadaEmail: true,
           })

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -175,6 +175,7 @@ class Home extends React.Component {
           this.setState({
             isEmailDomainValid: false,
             isCanadaEmail: false,
+            emailInput: email,
           })
           // Check if the user is trying to put a canada.ca email
           if(invalidDomains.includes(domain[1])){
@@ -194,23 +195,29 @@ class Home extends React.Component {
         }
         this.state.domainList.map((domState) => {
             if (domState.dom === domain[1]) {
-                if (mailType === 'email') {
-                    console.log("domstatekey " + domState.key + " domstate " + domState.dom + " domain " + domain[1])
+              if (mailType === 'email') {
+                console.log("domstatekey " + domState.key + " domstate " + domState.dom + " domain " + domain[1])
 
-              this.setState({
-                department: {key: domState.key},
-                isEmailDomainValid: true,
-                emailInput: email,
-              })
+                this.setState({
+                  department: {key: domState.key},
+                  isEmailDomainValid: true,
+                })
                 console.log("depat key" + domState.key)
-            } else {
-              this.setState({
-                isCloudDomainValid: true,
-                cloudEmail: email,
-              })
+              } else {
+                this.setState({
+                  isCloudDomainValid: true,
+                  cloudEmail: email,
+                })
+              }
             }
-          }
         })
+
+        // Add check for unrecognized domains that are not in invalid domain list
+        if(!this.state.isEmailDomainValid) {
+          this.setState({
+            isCanadaEmail: true,
+          })
+        }
       }
     }
   }


### PR DESCRIPTION
Add check for first email field to catch emails not in domain list or in the invalid domain list.

Displays normal `Must be a departmental email address` error. 